### PR TITLE
Update my_debugger.py

### DIFF
--- a/src/chapter3/3.3/my_debugger.py
+++ b/src/chapter3/3.3/my_debugger.py
@@ -142,7 +142,7 @@ class Debugger():
                 elif self.exception == EXCEPTION_SINGLE_STEP:
                     print("Single Stepping")
             
-            kernel32.ContinueDebugEvent(
+        kernel32.ContinueDebugEvent(
                 debug_event.dwProcessId,
                 debug_event.dwThreadId,
                 continue_status)


### PR DESCRIPTION
fix `get_debug_event()`: Cancel one level of indentation of `kernel32.ContinueDebugEvent()`, otherwise it will not trigger the debug event with event code 1